### PR TITLE
5: Add quadrophonic as an audio config type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ gh-pages -d build
 
 This web app was scaffolded using [`create-elm-app`](https://www.npmjs.com/package/create-elm-app) and styled with assistance from [Bulma](https://bulma.io/).
 
-Cheers to [Ashley Blewer](https://github.com/ablwr), [Kieran O'Leary](https://github.com/kieranjol), [Reto Kromer](https://github.com/retokromer), [Andrew Weaver](https://github.com/privatezero), and [Dave Rice](https://github.com/dericed) for providing feedback and encouragement! Especial thanks to Reto for his translation help. Also, shoutout to [Corey Bailey](http://www.baileyzone.net/) for providing info on 3" audio reels.
+Cheers to [Ashley Blewer](https://github.com/ablwr), [Kieran O'Leary](https://github.com/kieranjol), [Reto Kromer](https://github.com/retokromer), [Andrew Weaver](https://github.com/privatezero), and [Dave Rice](https://github.com/dericed) for providing feedback and encouragement! Especial thanks to Reto for his translation help. Also, shoutout to [Corey Bailey](http://www.baileyzone.net/) for providing info on 3" audio reels and quadraphonic audio.

--- a/src/Calculations.elm
+++ b/src/Calculations.elm
@@ -58,6 +58,8 @@ reelLengthInFeet reel =
 
 
 -- The baseDuration is the duration of the reel if recorded at the maximum speed of 30ips.
+
+
 baseDuration : Reel -> Float
 baseDuration reel =
     let
@@ -152,6 +154,9 @@ filesize fileType reel =
 
                 QuarterTrackStereo ->
                     2
+
+                Quadraphonic ->
+                    4
 
                 _ ->
                     1

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -40,9 +40,13 @@ reelInfo config =
         QuarterTrackMono ->
             ( Bidirectional, 4 )
 
+        Quadraphonic ->
+            ( Unidirectional, 1 )
+
 
 audioConfigFromString : String -> Maybe AudioConfig
 audioConfigFromString name =
+    -- TODO replace these kind of FNs with a lookup, this is a risky approach.
     case name of
         "FullTrackMono" ->
             Just FullTrackMono
@@ -58,6 +62,9 @@ audioConfigFromString name =
 
         "QuarterTrackMono" ->
             Just QuarterTrackMono
+
+        "Quadraphonic" ->
+            Just Quadraphonic
 
         _ ->
             Nothing
@@ -80,6 +87,9 @@ audioConfigDisplayName audioConfig =
 
         QuarterTrackMono ->
             QuarterTrackMonoStr
+
+        Quadraphonic ->
+            QuadraphonicStr
 
 
 diameterFromString : String -> Maybe DiameterInInches

--- a/src/Translate.elm
+++ b/src/Translate.elm
@@ -44,6 +44,7 @@ type AppString
     | PassesStr Int
     | ResponsiveStr
     | PerReelStr String
+    | QuadraphonicStr
     | QAndAStr
     | QuantityStr
     | QuarterTrackMonoStr
@@ -180,6 +181,12 @@ translate language appString =
                     { en = str ++ " per reel"
                     , fr = str ++ " par bobine"
                     , it = str ++ " per bobina"
+                    }
+
+                QuadraphonicStr ->
+                    { en = "quadraphonic (4-track)"
+                    , fr = "quadriphonique (4 pistes)"
+                    , it = "quadrifonico (4 canali)"
                     }
 
                 QAndAStr ->

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -66,11 +66,12 @@ type AudioConfig
     | HalfTrackMono
     | QuarterTrackStereo
     | QuarterTrackMono
+    | Quadraphonic
 
 
 allAudioConfigs : List AudioConfig
 allAudioConfigs =
-    [ FullTrackMono, HalfTrackStereo, HalfTrackMono, QuarterTrackStereo, QuarterTrackMono ]
+    [ FullTrackMono, HalfTrackStereo, HalfTrackMono, QuarterTrackStereo, QuarterTrackMono, Quadraphonic ]
 
 
 type DiameterInInches

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -147,6 +147,33 @@ all =
                 in
                 \_ -> Expect.equal size 1518.75
             ]
+        , describe "quadraphonic (4-track), 7\" 1.0mil @ 7.5 IPS" <|
+            let
+                reel =
+                    newReel fakeUUID (SelectorValues Quadraphonic Seven Mil1p0 IPS_7p5 (Just 1)) 1
+            in
+            [ test "should be 1 pass" <|
+                \_ ->
+                    Expect.equal reel.passes 1
+            , test "reel footage should be 1800ft" <|
+                let
+                    footage =
+                        reelLengthInFeet reel
+                in
+                \_ -> Expect.equal footage Ft1800
+            , test "duration should be 45 minutes" <|
+                let
+                    duration =
+                        fullDuration reel
+                in
+                \_ -> Expect.equal duration 45
+            , test "should be 1518.75 MB in size for a 24/96 WAV" <|
+                let
+                    size =
+                        filesize WAV_24_96 reel
+                in
+                \_ -> Expect.equal size 3037.5
+            ]
         ]
 
 


### PR DESCRIPTION
Addresses #5 

Quadraphonic was a four-track surround-sound format. All tracks were recorded in one direction and the assignment was: (tracks 1-4) Left, Right, Left Rear, Right Rear.

Corey Bailey informs me that commercially recorded quadraphonic was typically 7.5ips.

Another side note which I meant to include in the commit message for the 3" reels commit: also per Corey Bailey, 3" reels were most often recorded at 3.75ips, and are likely to be half-track mono.