### PR TITLE
1: Use CSV builder on JS side

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,23 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "csv-stringify": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-3.1.1.tgz",
+      "integrity": "sha512-Ni9r/BdQM2cGnWzwAP09zp12LVOAMHLJ86azNHGC7s4OUo2WidGfcM3QwYEjD8c4ELCL/a4AzfIsVCzroeys+g==",
+      "requires": {
+        "lodash.get": "~4.4.2"
+      }
+    },
     "file-saver": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
       "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "csv-stringify": "^3.1.1",
     "file-saver": "^1.3.3"
   },
   "devDependencies": {},

--- a/src/CsvOutput.elm
+++ b/src/CsvOutput.elm
@@ -6,73 +6,58 @@ import AudioFile exposing (FileType(..), fileTypeName, totalFilesize)
 import Translate exposing (AppString(..), Language, audioConfigDisplayName, directionString, translate)
 
 
-delimiter : String
-delimiter =
-    ","
-
-
-dataForCSV : Language -> FileType -> List Reel -> String
+dataForCSV : Language -> FileType -> List Reel -> List (List String)
 dataForCSV lang fileType reels =
-    let
-        lineBreak =
-            "\n"
-
-        csvLines =
-            headerRow lang
-                :: List.map (reelRow lang) reels
-                ++ [ lineBreak
-                   , totalRow lang reels
-                   , sizeRow lang fileType reels
-                   ]
-    in
-    String.concat <| List.intersperse lineBreak csvLines
+    [ headerRow lang ]
+        ++ List.map (reelRow lang) reels
+        ++ [ totalRow lang reels
+           , sizeRow lang fileType reels
+           ]
 
 
-headerRow : Language -> String
+headerRow : Language -> List String
 headerRow lang =
-    String.join delimiter
-        [ translate lang TypeStr
-        , translate lang DiameterStr
-        , translate lang ThicknessStr
-        , translate lang SpeedStr
-        , translate lang QuantityStr
-        , translate lang DirectionStr
-        , translate lang PassesStr
-        , translate lang FootagePerReelStr
-        , translate lang (PerReelStr <| translate lang MinutesStr)
-        , translate lang TotalDurationStr
-        ]
+    [ translate lang TypeStr
+    , translate lang DiameterStr
+    , translate lang ThicknessStr
+    , translate lang SpeedStr
+    , translate lang QuantityStr
+    , translate lang DirectionStr
+    , translate lang PassesStr
+    , translate lang FootagePerReelStr
+    , translate lang (PerReelStr <| translate lang MinutesStr)
+    , translate lang TotalDurationStr
+    ]
 
 
-reelRow : Language -> Reel -> String
+reelRow : Language -> Reel -> List String
 reelRow language reel =
-    String.join delimiter
-        [ translate language <| audioConfigDisplayName reel.audioConfig
-        , diameterImperialName reel.diameter
-        , tapeThicknessDisplayName reel.tapeThickness
-        , speedImperialName reel.recordingSpeed
-        , toString reel.quantity
-        , translate language (directionString reel.directionality)
-        , toString reel.passes
-        , toString <| footageToInt (reelLengthInFeet reel)
-        , toString <| singleReelDuration reel
-        , toString <| fullDuration reel
-        ]
+    [ translate language <| audioConfigDisplayName reel.audioConfig
+    , diameterImperialName reel.diameter
+    , tapeThicknessDisplayName reel.tapeThickness
+    , speedImperialName reel.recordingSpeed
+    , toString reel.quantity
+    , translate language (directionString reel.directionality)
+    , toString reel.passes
+    , toString <| footageToInt <| reelLengthInFeet reel
+    , toString <| singleReelDuration reel
+    , toString <| fullDuration reel
+    ]
 
 
-totalRow : Language -> List Reel -> String
+totalRow : Language -> List Reel -> List String
 totalRow lang reels =
-    String.repeat 7 delimiter
-        ++ translate lang TotalDurationStr
-        ++ String.repeat 2 delimiter
-        ++ (toString <| overallDuration reels)
+    List.repeat 7 ""
+        ++ [ translate lang TotalDurationStr
+           , ""
+           , toString <| overallDuration reels
+           ]
 
 
-sizeRow : Language -> FileType -> List Reel -> String
+sizeRow : Language -> FileType -> List Reel -> List String
 sizeRow lang fileType reels =
-    String.repeat 7 delimiter
-        ++ translate lang FileSizeStr
-        ++ delimiter
-        ++ fileTypeName fileType
-        ++ delimiter
-        ++ translate lang (SizeInMegaBytesStr <| totalFilesize fileType reels)
+    List.repeat 7 ""
+        ++ [ translate lang FileSizeStr
+           , fileTypeName fileType
+           , translate lang (SizeInMegaBytesStr <| totalFilesize fileType reels)
+           ]

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -1,4 +1,4 @@
 port module Ports exposing (..)
 
 
-port exportData : String -> Cmd msg
+port exportData : List (List String) -> Cmd msg

--- a/src/Update.elm
+++ b/src/Update.elm
@@ -141,10 +141,10 @@ update msg model =
 
         StartExport ->
             let
-                csvString =
+                csvData =
                     dataForCSV model.language model.fileType model.reels
             in
-            ( model, Ports.exportData csvString )
+            ( model, Ports.exportData csvData )
 
         NoOp ->
             ( model, Cmd.none )

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import "../styles/main.css";
 import { Main } from "./Main.elm";
 import registerServiceWorker from "./registerServiceWorker";
 import * as fileSaver from "file-saver";
+import * as stringify from "../node_modules/csv-stringify/lib/es5/index";
 
 const app = Main.embed(document.getElementById("root"));
 
@@ -12,9 +13,11 @@ registerServiceWorker();
 app.ports.exportData.subscribe(content => {
   const fileName = "reel-time_summary.csv";
 
-  const blob = new Blob([content], {
-    type: "data:text/csv;charset=utf-8"
-  });
+  stringify(content, function(err, output) {
+    const blob = new Blob([output], {
+      type: "data:text/csv;charset=utf-8"
+    });
 
-  fileSaver.saveAs(blob, fileName);
+    fileSaver.saveAs(blob, fileName);
+  });
 });


### PR DESCRIPTION
This was [Nick](https://github.com/Widdershin)'s suggestion - since CSV is more fiddly than it appears, he recommended to use a CSV builder so that all escaping rules are accounted for, etc.

Therefore, I'm now sending through the CSV data through the port as lists of strings, rather than a single string with delimiters already included. On the JS side, the CSV builder library takes care of the CSV generation.
I've imported the ES5 version of the module to avoid an Uglify error during the app build.

Addresses https://github.com/kfrn/reel-time/issues/1